### PR TITLE
LoadAddon() moved into C_AddOns namespace in 11.0

### DIFF
--- a/KeyMaster.lua
+++ b/KeyMaster.lua
@@ -143,7 +143,7 @@ local function OnEvent_AddonLoaded(self, event, name, ...)
 
     SLASH_FRAMESTK1 = "/fs"
 	SlashCmdList.FRAMESTK = function()
-		LoadAddOn("Blizzard_DebugTools")
+		C_AddOns.LoadAddOn("Blizzard_DebugTools")
 		FrameStackTooltip_Toggle()
 	end
 


### PR DESCRIPTION
When trying to use the /fs slash command, an old reference to LoadAddon() is still present (was deprecated in 10.0, removed in 11.0)