### PR TITLE
fix timer threshold calculations for level 7 and up

### DIFF
--- a/Libs/Internal/DungeonTools.lua
+++ b/Libs/Internal/DungeonTools.lua
@@ -425,11 +425,14 @@ function DungeonTools:CalculateChest(dungeonID, keyLevel, timeCompleted)
     end
     local timeLimit = currentSeasonMaps[dungeonID].timeLimit
     if keyLevel >= seasonVars.thirdAffixLevel then
-        timeLimit = timeLimit + 90
+        if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)+90) then return "+++" end
+        if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)+90) then return "++" end
+        if(timeCompleted <= timeLimit+90) then return "+" end
+    else
+        if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)) then return "+++" end
+        if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)) then return "++" end
+        if(timeCompleted <= timeLimit) then return "+" end
     end
-    if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)) then return "+++" end
-    if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)) then return "++" end
-    if(timeCompleted <= timeLimit) then return "+" end
     return ""
 end
 


### PR DESCRIPTION
Blizzard did some weirdness when they added the extra 90 seconds for  [Challenger's Peril](https://www.wowhead.com/affix=152/challengers-peril). Instead of it just adding 90s to the whole timer, they actually moved the thresholds for 1-, 2-, and 3-chesting by 90 seconds:
```
+---------+-----------------------+---------------------------------------+
| Dungeon |       Base Timer      |                +7 Timer               |
|         |                       +-------+---------------+---------------+
|         |                       |       |    Expected   |    Blizzard   |
|         +-------+-------+-------+-------+-------+-------+-------+-------+
|         |   +   |   ++  |  +++  |   +   |   ++  |  +++  |   ++  |  +++  |
+=========+=======+=======+=======+=======+=======+=======+=======+=======+
| MoTS    | 30:00 | 24:00 | 18:00 | 31:30 | 25:12 | 18:54 | 25:30 | 19:30 |
+---------+-------+-------+-------+-------+-------+-------+-------+-------+
| GB      | 34:00 | 27:12 | 20:24 | 35:30 | 28:24 | 21:18 | 28:42 | 21:54 |
+---------+-------+-------+-------+-------+-------+-------+-------+-------+
| CoT     | 35:00 | 28:00 | 21:00 | 36:30 | 29:12 | 21:54 | 29:30 | 22:30 |
+---------+-------+-------+-------+-------+-------+-------+-------+-------+
```

Currently, the 2-, and 3-chest calculations are (baseTimer+90)*0.8 and (baseTimer+90)*0.6; Blizzard is actually using (baseTimer*0.8)+90 and (baseTimer*0.6)+90