### PR TITLE
Development

### DIFF
--- a/Core/Localization/Localization.deDE.lua
+++ b/Core/Localization/Localization.deDE.lua
@@ -50,7 +50,7 @@ L.MAPNAMES[375] = { name = "Die Nebel von Tirna Scithe", abbr = "MTS" }
 L.MAPNAMES[376] = { name = "Die Nekrotische Schneise", abbr = "NW" }
 --TWW S2
 L.MAPNAMES[500] = { name = "Die Brutstätte", abbr = "Brut" }
-L.MAPNAMES[525] = { name = "Fluttor", abbr = "Flut" }
+L.MAPNAMES[525] = { name = "Schleuse", abbr = "Schl" }
 L.MAPNAMES[247] = { name = "Das RIESENFLÖZ!!", abbr = "Flöz" }
 L.MAPNAMES[370] = { name = "Mechagon - Werkstatt", abbr = "WERK" }
 L.MAPNAMES[504] = { name = "Dunkelflammenspalt", abbr = "DFS" }

--- a/Core/Localization/Localization.zhCN.lua
+++ b/Core/Localization/Localization.zhCN.lua
@@ -49,14 +49,14 @@ L.MAPNAMES[507] = { name = "The Grim Batol", abbr = "格瑞" }
 L.MAPNAMES[375] = { name = "Mists of Tirna Scithe", abbr = "仙林" }
 L.MAPNAMES[376] = { name = "The Necrotic Wake", abbr = "通灵" }
 --TWW S2
-L.MAPNAMES[500] = { name = "The Rookery", abbr = "RKY" }
-L.MAPNAMES[525] = { name = "Floodgate", abbr = "FG" }
-L.MAPNAMES[247] = { name = "The MOTHERLODE!!", abbr = "ML" }
-L.MAPNAMES[370] = { name = "Mechagon - Workshop", abbr = "WORK" }
-L.MAPNAMES[504] = { name = "Darkflame Cleft", abbr = "DFC" }
-L.MAPNAMES[382] = { name = "Theater of Pain", abbr = "ToP" }
-L.MAPNAMES[506] = { name = "Cinderbrew Meadery", abbr = "CBM" }
-L.MAPNAMES[499] = { name = "Priory of the Sacred Flame", abbr = "PoSF" }
+L.MAPNAMES[500] = { name = "The Rookery", abbr = "驭雷" }
+L.MAPNAMES[525] = { name = "Floodgate", abbr = "水闸" }
+L.MAPNAMES[247] = { name = "The MOTHERLODE!!", abbr = "暴富" }
+L.MAPNAMES[370] = { name = "Mechagon - Workshop", abbr = "麦卡贡" }
+L.MAPNAMES[504] = { name = "Darkflame Cleft", abbr = "暗焰" }
+L.MAPNAMES[382] = { name = "Theater of Pain", abbr = "剧场" }
+L.MAPNAMES[506] = { name = "Cinderbrew Meadery", abbr = "酒庄" }
+L.MAPNAMES[499] = { name = "Priory of the Sacred Flame", abbr = "圣焰" }
 
 L.XPAC = {}
 L.XPAC[0] = { enum = "LE_EXPANSION_CLASSIC", desc = "经典旧世" }

--- a/Core/UI/WhatsNew.lua
+++ b/Core/UI/WhatsNew.lua
@@ -33,15 +33,15 @@ local function setWhatsNewContent(parent)
                 <br/>
                 <h2>|cff]]..h2Color..[[Updates:|r</h2>
                 <br/>
-                <p>]]..textBullet..[[Updated to interface version 11.1</p>
-                <br/>
-                <p>]]..textBullet..[[Will be loosing CN translation next release due to lack of translator participation.</p>          
-                <br/>
-                <p>]]..textBullet..[[Updates for TWW S2.</p>
+                <p>]]..textBullet..[[Added simplified Chinese translations for S2 dungeons.  (Thanks vj234013 on github)</p>
                 <br/>
                 <h2>|cff]]..h2Color..[[Fixes:|r</h2>
                 <br/>
-                <p>]]..textBullet..[[None.</p>
+                <p>]]..textBullet..[[Fixed score calulations for TWW S2 (special thanks to OMGTotem).</p>
+                <br/>
+                <p>]]..textBullet..[[Fixed chest ++ calculation for dungeons since the 90s addition to dungeon timers is gone.</p>
+                <br/>
+                <p>]]..textBullet..[[Fixed portal spell ids for Motherlode and Operation: Floodgate dungeons.  (Thanks snaysix on github)</p>
                 <br/>
                 <br/>
                 <h2>|cff]]..h2Color..[[Known Bugs/Issues:|r</h2>

--- a/KeyMaster.lua
+++ b/KeyMaster.lua
@@ -18,7 +18,7 @@ local PartyFrame = KeyMaster.PartyFrame
 KM_ADDON_NAME = KeyMasterLocals.ADDONNAME
 KM_AUTOVERSION = C_AddOns.GetAddOnMetadata("KeyMaster", "Version")
 
-KM_VERSION_STATUS = KeyMasterLocals.BUILDBETA -- BUILDALPHA BUILDBETA BUILDRELEASE - for display and update notification purposes
+KM_VERSION_STATUS = KeyMasterLocals.BUILDRELEASE -- BUILDALPHA BUILDBETA BUILDRELEASE - for display and update notification purposes
 
 --------------------------------
 -- Slash Commands and command menu

--- a/KeyMaster.lua
+++ b/KeyMaster.lua
@@ -18,7 +18,7 @@ local PartyFrame = KeyMaster.PartyFrame
 KM_ADDON_NAME = KeyMasterLocals.ADDONNAME
 KM_AUTOVERSION = C_AddOns.GetAddOnMetadata("KeyMaster", "Version")
 
-KM_VERSION_STATUS = KeyMasterLocals.BUILDRELEASE -- BUILDALPHA BUILDBETA BUILDRELEASE - for display and update notification purposes
+KM_VERSION_STATUS = KeyMasterLocals.BUILDBETA -- BUILDALPHA BUILDBETA BUILDRELEASE - for display and update notification purposes
 
 --------------------------------
 -- Slash Commands and command menu

--- a/KeyMaster.toc
+++ b/KeyMaster.toc
@@ -2,7 +2,7 @@
 ## X-Max-Interface: 110100
 ## X-Min-Interface: 110002
 
-## Version: 1.4.0
+## Version: 1.4.1
 ## Title: |cffb09c60Key Master|r
 ## Title-ptBR: |cffb09c60Key Master|r
 ## Title-ruRU: |cffb09c60Key Master|r [|cffe6b080Мастер ключей|r]

--- a/KeyMaster.toc
+++ b/KeyMaster.toc
@@ -2,7 +2,7 @@
 ## X-Max-Interface: 110100
 ## X-Min-Interface: 110002
 
-## Version: 1.4.1
+## Version: 1.4.2
 ## Title: |cffb09c60Key Master|r
 ## Title-ptBR: |cffb09c60Key Master|r
 ## Title-ruRU: |cffb09c60Key Master|r [|cffe6b080Мастер ключей|r]

--- a/Libs/Internal/DungeonTools.lua
+++ b/Libs/Internal/DungeonTools.lua
@@ -388,6 +388,26 @@ local function getRatingCalcValues()
             twoChestSpeed = 0.8, -- timer % at which a dungeon is 2 chested.
             threeChestSpeed = 0.6, -- timer % at which a dungeon is 3 chested
             bonusTimerRating = 15 -- Bonus/Penalty for timers
+        },
+        [14] = { -- TWW S2 --- TO BE VERIFIED ------
+            baseRating = 125, -- Base score for dungeon completion
+            firstAffixLevel = 4, -- lowest M+ Key possible
+            fistAffixValue = 15, -- Value of the first affix
+            secondAffixLevel = 7, -- Key level the second affix is added
+            secondAffixValue = 15, -- Value of the second affix
+            thirdAffixLevel = 10, -- Key level the third affix is added
+            thirdAffixValue = 15, -- Value of the thrid affix
+            fourthAffixLevel = 12, -- Key level the third affix is added
+            fourthAffixValue = 15, -- Value of the thrid affix
+            fifthAffixLevel = 12, -- Key level the third affix is added
+            fifthAffixValue = 0, -- Value of the thrid affix
+            thresholdLevel = 1, -- Threshold after which the value of the key changes due to level
+            preThresholdValue = 15, -- Value of the pre-threshold levels
+            postThresholdValue = 15, -- Value of the post threshold levels
+            untimedBaseLevel = 10, -- The level after which untimed keys have no additional value
+            twoChestSpeed = 0.8, -- timer % at which a dungeon is 2 chested.
+            threeChestSpeed = 0.6, -- timer % at which a dungeon is 3 chested
+            bonusTimerRating = 15 -- Bonus/Penalty for timers
         }
     }
 
@@ -531,18 +551,17 @@ function DungeonTools:CalculateRating(dungeonID, keyLevel, runTime)
         return 0
     end
     
-    if (keyLevel < seasonVars.firstAffixLevel) then
+    -- In Season 2 of TWW they moved based affix to level 4. So this is removed.
+    --[[ if (keyLevel < seasonVars.firstAffixLevel) then
         return 0
-    end
+    end ]]
 
     if currentSeasonMaps == nil then
         currentSeasonMaps = DungeonTools:GetCurrentSeasonMaps()
     end
     local bonusRating = 0
     local dungeonTimeLimit = currentSeasonMaps[dungeonID].timeLimit
-    if keyLevel >= seasonVars.thirdAffixLevel then
-        dungeonTimeLimit = dungeonTimeLimit + 90
-    end
+    
     -- Runs over time by 40% are a 0 score.
     if(runTime > (dungeonTimeLimit + (dungeonTimeLimit * maxModifier))) then
         return 0

--- a/Libs/Internal/DungeonTools.lua
+++ b/Libs/Internal/DungeonTools.lua
@@ -57,14 +57,14 @@ local portalSpellIds = {
     [375] = 354464,      -- Mists of Tirna Scithe - 348533
     [376] = 354462,      -- The Necrotic Wake - 348529
     -- TWW S2
-    [500] = 445443,      -- The Rookery - 445443
-    [525] = 1218105,     -- Floodgate - 1218105
-    [247] = 272268,      -- The MOTHERLODE!! - 272268
-    [370] = 373274,      -- Mechagon - Workshop - 373274
-    [504] = 445441,      -- Darkflame Cleft - 445441
-    [382] = 354467,      -- Theater of Pain - 354467
-    [506] = 445440,      -- Cinderbrew Meadery - 445440
-    [499] = 445444       -- Priory of the Sacred Flame - 445444
+    [500] = 445443,      -- The Rookery
+    [525] = 1216786,     -- Floodgate
+    [247] = 467553,      -- The MOTHERLODE!!
+    [370] = 373274,      -- Mechagon - Workshop
+    [504] = 445441,      -- Darkflame Cleft
+    [382] = 354467,      -- Theater of Pain
+    [506] = 445440,      -- Cinderbrew Meadery
+    [499] = 445444       -- Priory of the Sacred Flame
 }
 
 -- add only horde specific portals here.
@@ -454,9 +454,9 @@ function DungeonTools:CalculateChest(dungeonID, keyLevel, timeCompleted)
     end
     local timeLimit = currentSeasonMaps[dungeonID].timeLimit
     if keyLevel >= seasonVars.thirdAffixLevel then
-        if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)+90) then return "+++" end
-        if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)+90) then return "++" end
-        if(timeCompleted <= timeLimit+90) then return "+" end
+        if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)) then return "+++" end
+        if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)) then return "++" end
+        if(timeCompleted <= timeLimit) then return "+" end
     else
         if(timeCompleted <= (timeLimit * seasonVars.threeChestSpeed)) then return "+++" end
         if(timeCompleted <= (timeLimit * seasonVars.twoChestSpeed)) then return "++" end

--- a/PatchNotes.txt
+++ b/PatchNotes.txt
@@ -3,6 +3,18 @@ Key Master AddOn for World of Warcraft
 
 PATCH NOTES:
 --------------------------------------------------
+Key Master v1.4.1
+--------------------------------------------------
+Updates:
+- None
+
+Fixes:
+- None
+
+Known Bugs/Issues:
+- A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.
+
+--------------------------------------------------
 Key Master v1.4.0
 --------------------------------------------------
 Updates:
@@ -22,7 +34,7 @@ Fixes:
 
 Known Bugs/Issues:
 - A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.
-PATCH NOTES:
+
 --------------------------------------------------
 Key Master v1.3.9
 --------------------------------------------------

--- a/PatchNotes.txt
+++ b/PatchNotes.txt
@@ -7,6 +7,7 @@ Key Master v1.4.2
 --------------------------------------------------
 Updates:
 - Added simplified Chinese translations for S2 dungeons.  (Thanks vj234013 on github)
+- Updated DE localization
 
 Fixes:
 - Fixed score calulations for TWW S2 (special thanks to OMGTotem)
@@ -16,7 +17,6 @@ Fixes:
 Known Bugs/Issues:
 - A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.
 
-PATCH NOTES:
 --------------------------------------------------
 Key Master v1.4.1
 --------------------------------------------------

--- a/PatchNotes.txt
+++ b/PatchNotes.txt
@@ -3,6 +3,21 @@ Key Master AddOn for World of Warcraft
 
 PATCH NOTES:
 --------------------------------------------------
+Key Master v1.4.2
+--------------------------------------------------
+Updates:
+- Added simplified Chinese translations for S2 dungeons.  (Thanks vj234013 on github)
+
+Fixes:
+- Fixed score calulations for TWW S2 (special thanks to OMGTotem)
+- Fixed chest ++ calculation for dungeons since the 90s addition to dungeon timers is gone.
+- Fixed portal spell ids for Motherlode and Operation: Floodgate dungeons.  (Thanks snaysix on github)
+
+Known Bugs/Issues:
+- A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.
+
+PATCH NOTES:
+--------------------------------------------------
 Key Master v1.4.1
 --------------------------------------------------
 Updates:


### PR DESCRIPTION
PATCH NOTES:
--------------------------------------------------
Key Master v1.4.2
--------------------------------------------------
Updates:
- Added simplified Chinese translations for S2 dungeons.  (Thanks vj234013 on github)
- Updated DE localization

Fixes:
- Fixed score calulations for TWW S2 (special thanks to OMGTotem)
- Fixed chest ++ calculation for dungeons since the 90s addition to dungeon timers is gone.
- Fixed portal spell ids for Motherlode and Operation: Floodgate dungeons.  (Thanks snaysix on github)

Known Bugs/Issues:
- A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.