### PR TITLE
fixed motherlode portal for horde characters.

### DIFF
--- a/Core/UI/WhatsNew.lua
+++ b/Core/UI/WhatsNew.lua
@@ -32,16 +32,12 @@ local function setWhatsNewContent(parent)
                 <br/>
                 <br/>
                 <h2>|cff]]..h2Color..[[Updates:|r</h2>
+                <p>]]..textBullet..[[None.</p>
                 <br/>
-                <p>]]..textBullet..[[Added simplified Chinese translations for S2 dungeons.  (Thanks vj234013 on github)</p>
                 <br/>
                 <h2>|cff]]..h2Color..[[Fixes:|r</h2>
                 <br/>
-                <p>]]..textBullet..[[Fixed score calulations for TWW S2 (special thanks to OMGTotem).</p>
-                <br/>
-                <p>]]..textBullet..[[Fixed chest ++ calculation for dungeons since the 90s addition to dungeon timers is gone.</p>
-                <br/>
-                <p>]]..textBullet..[[Fixed portal spell ids for Motherlode and Operation: Floodgate dungeons.  (Thanks snaysix on github)</p>
+                <p>]]..textBullet..[[Fixed Motherlode portal for horde characters (thanks to snaysix on github for catching this).</p>
                 <br/>
                 <br/>
                 <h2>|cff]]..h2Color..[[Known Bugs/Issues:|r</h2>

--- a/KeyMaster.toc
+++ b/KeyMaster.toc
@@ -2,7 +2,7 @@
 ## X-Max-Interface: 110100
 ## X-Min-Interface: 110002
 
-## Version: 1.4.2
+## Version: 1.4.3
 ## Title: |cffb09c60Key Master|r
 ## Title-ptBR: |cffb09c60Key Master|r
 ## Title-ruRU: |cffb09c60Key Master|r [|cffe6b080Мастер ключей|r]

--- a/Libs/Internal/DungeonTools.lua
+++ b/Libs/Internal/DungeonTools.lua
@@ -52,14 +52,14 @@ local portalSpellIds = {
     [502] = 445416,      -- City of Threads - 442927
     [505] = 445414,      -- The Dawnbreaker - 442931
     [501] = 445269,      -- The Stonevault - 442926
-    [353] = 445418,      -- Siege of Boralus - (A) 445418 - (H) 464256 - 272264
+    [353] = 445418,      -- Siege of Boralus (alliance ONLY)
     [507] = 445424,      -- The Grim Batol - 396121
     [375] = 354464,      -- Mists of Tirna Scithe - 348533
     [376] = 354462,      -- The Necrotic Wake - 348529
     -- TWW S2
     [500] = 445443,      -- The Rookery
     [525] = 1216786,     -- Floodgate
-    [247] = 467553,      -- The MOTHERLODE!!
+    [247] = 467553,      -- The MOTHERLODE!! (alliance ONLY)
     [370] = 373274,      -- Mechagon - Workshop
     [504] = 445441,      -- Darkflame Cleft
     [382] = 354467,      -- Theater of Pain
@@ -69,7 +69,8 @@ local portalSpellIds = {
 
 -- add only horde specific portals here.
 local portalSpellIdsHorde = {
-    [353] = 464256      -- Siege of Boralus - (A) 445418 - (H) 464256 - 272264
+    [353] = 464256,      -- Siege of Boralus 
+    [247] = 467555      -- The MOTHERLODE!! 
 }
 
 -- Affix IDs

--- a/PatchNotes.txt
+++ b/PatchNotes.txt
@@ -3,6 +3,19 @@ Key Master AddOn for World of Warcraft
 
 PATCH NOTES:
 --------------------------------------------------
+Key Master v1.4.3
+--------------------------------------------------
+Updates:
+- 
+
+Fixes:
+- Fixed Motherlode portal for horde characters (thanks to snaysix on github for catching this).
+
+Known Bugs/Issues:
+- A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.
+
+PATCH NOTES:
+--------------------------------------------------
 Key Master v1.4.2
 --------------------------------------------------
 Updates:


### PR DESCRIPTION
PATCH NOTES:
--------------------------------------------------
Key Master v1.4.3
--------------------------------------------------
Updates:
- 

Fixes:
- Fixed Motherlode portal for horde characters (thanks to snaysix on github for catching this).

Known Bugs/Issues:
- A player's vault display may not update immediately. Changing tabs should correct the display if inaccurate.